### PR TITLE
Added timeout to tmate and removed extra instance

### DIFF
--- a/.github/workflows/validateCommitSimulator.yml
+++ b/.github/workflows/validateCommitSimulator.yml
@@ -153,9 +153,7 @@ jobs:
       - name: Setup tmate session 3 (if failed)
         uses: mxschmitt/action-tmate@v3
         if: ${{ failure() }}
-        
-      - name: Setup tmate session 3
-        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 40
 
       - name: Save test results
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Please summarize the bugs that this PR fixes. As relevant, please indicate the issues that the PR closes.

Fixes issue where tmate session would run for way too long on failure, or run on success anyway.
